### PR TITLE
Try qmake-qt4 before giving up on qmake.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,8 @@ OPTION_OSXARCH = option_value("osx-arch")
 
 if OPTION_QMAKE is None:
     OPTION_QMAKE = find_executable("qmake")
+if OPTION_QMAKE is None:
+    OPTION_QMAKE = find_executable("qmake-qt4")
 if OPTION_CMAKE is None:
     OPTION_CMAKE = find_executable("cmake")
 


### PR DESCRIPTION
This is specially useful when installing from PyPI with `pip`, that passing --qmake is not as simple as `setup.py` approach.
When I try to install PySide on Fedora I get error about qmake, even though qmake is installed. Its name is not qmake but qmake-qt4. 