### PR TITLE
Add 3.5 to the list of supported versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ without rebuilding entire PySide every time:
   python setup.py bdist_egg --only-package --qmake=c:\Qt\4.8.5\bin\qmake.exe --cmake=c:\tools\cmake\bin\cmake.exe --opnessl=c:\libs\OpenSSL32bit\bin
 
 REQUIREMENTS:
-- Python: 2.6, 2.7, 3.2, 3.3 and 3.4 is supported
+- Python: 2.6, 2.7, 3.2, 3.3, 3.4 and 3.5 is supported
 - Cmake: Specify the path to cmake with --cmake option or add cmake to the system path.
 - Qt: 4.6, 4.7 and 4.8 is supported. Specify the path to qmake with --qmake option or add qmake to the system path.
 
@@ -1005,6 +1005,7 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Database',
         'Topic :: Software Development',
         'Topic :: Software Development :: Code Generators',


### PR DESCRIPTION
Currently, `setup.py` errors out on python 3.5, because it refuses to install on any version of Python that isn't explicitly listed in the Trove classifiers. This adds 3.5 to the list of supported versions.

This appears to be the only change required to support 3.5 -- after making this change to a 1.2.4 source tree then I tested on Linux and was able to build a wheel on 3.5 that built without errors and seems to be working fine in cursory testing (e.g. starting up matplotlib and opening a plot window, using PySide as the gui backend).
