### PR TITLE
Setup: Prevent encoding issue while installing package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -970,9 +970,9 @@ class pyside_build(_build):
 
 
 try:
-    with open(os.path.join(script_dir, 'README.rst')) as f:
+    with open(os.path.join(script_dir, 'README.rst'), 'r', encoding='utf-8') as f:
         README = f.read()
-    with open(os.path.join(script_dir, 'CHANGES.rst')) as f:
+    with open(os.path.join(script_dir, 'CHANGES.rst'), 'r', encoding='utf-8') as f:
         CHANGES = f.read()
 except IOError:
     README = CHANGES = ''


### PR DESCRIPTION
Python opens files using the encoding returned by
locale.getpreferredencoding(), which is 'cp1252' in Windows.
For cross-platform compatibility, it is needed to explicitly
specify 'utf-8' when reading files.

File is also opened in read-only since it is not necessary
to have write access to README and CHANGES files during install.