### PR TITLE
Fix a bug in qtattributionsscannertorst.py

### DIFF
--- a/sources/pyside6/doc/qtattributionsscannertorst.py
+++ b/sources/pyside6/doc/qtattributionsscannertorst.py
@@ -100,7 +100,7 @@ def readFile(fileName):
 def runScanner(directory, targetFileName):
     # qtattributionsscanner recursively searches for qt_attribution.json files
     # and outputs them in JSON with the paths of the 'LicenseFile' made absolute
-    libexec_b = subprocess.check_output('qtpaths -query QT_INSTALL_LIBEXECS',
+    libexec_b = subprocess.check_output('qtpaths --query QT_INSTALL_LIBEXECS',
                                         shell=True)
     libexec = libexec_b.decode('utf-8').strip()
     scanner = os.path.join(libexec, 'qtattributionsscanner')


### PR DESCRIPTION
buggy code
```py
libexec_b = subprocess.check_output('qtpaths -query QT_INSTALL_LIBEXECS',
                                    shell=True)
```

fixed
```py
libexec_b = subprocess.check_output('qtpaths --query QT_INSTALL_LIBEXECS',
                                    shell=True)
```

BTW, there is another bug here, e.g. on Manjaro when both qt5 and qt6 are installed, `qtpaths` here refers to qt5, and `qtpaths` for qt6 is `/usr/lib/qt6/bin/qtpaths`. `setup.py` has an option `--qtpaths`, I don't know how to use it here.